### PR TITLE
AC-953 : CSV roles split into array

### DIFF
--- a/src/modules/workflows/__snapshots__/workflows.service.spec.ts.snap
+++ b/src/modules/workflows/__snapshots__/workflows.service.spec.ts.snap
@@ -42,9 +42,7 @@ exports[`WorkflowsService createWorkflow valid reviewer roles returns expected r
   "tasks": [
     {
       "args": {
-        "reviewer_roles": [
-          "clinician",
-        ],
+        "reviewer_roles": "clinician, admin",
       },
       "id": "clinical-review-task",
       "type": "aide_clinical_review",
@@ -83,9 +81,7 @@ exports[`WorkflowsService editWorkflow valid reviewer roles returns expected res
   "tasks": [
     {
       "args": {
-        "reviewer_roles": [
-          "clinician",
-        ],
+        "reviewer_roles": "clinician",
       },
       "id": "clinical-review-task",
       "type": "aide_clinical_review",

--- a/src/modules/workflows/workflows.service.spec.ts
+++ b/src/modules/workflows/workflows.service.spec.ts
@@ -148,7 +148,7 @@ describe('WorkflowsService', () => {
           {
             id: 'clinical-review-task',
             type: 'aide_clinical_review',
-            args: { reviewer_roles: ['clinician'] },
+            args: { reviewer_roles: 'clinician, admin' },
           },
         ],
       };
@@ -269,7 +269,7 @@ describe('WorkflowsService', () => {
           {
             id: 'clinical-review-task',
             type: 'aide_clinical_review',
-            args: { reviewer_roles: ['clinician'] },
+            args: { reviewer_roles: 'clinician' },
           },
         ],
       };
@@ -382,7 +382,7 @@ describe('WorkflowsService', () => {
           {
             id: 'clinical-review-task',
             type: 'aide_clinical_review',
-            args: { reviewer_roles: ['clinician'] },
+            args: { reviewer_roles: 'clinician' },
           },
         ],
       };
@@ -462,7 +462,7 @@ describe('WorkflowsService', () => {
           {
             id: 'clinical-review-task',
             type: 'aide_clinical_review',
-            args: { reviewer_roles: ['clinician'] },
+            args: { reviewer_roles: 'clinician' },
           },
         ],
       };

--- a/src/modules/workflows/workflows.service.ts
+++ b/src/modules/workflows/workflows.service.ts
@@ -111,7 +111,7 @@ export class WorkflowsService {
 
     for (const reviewTask of clinicalReviewTasks) {
       const commaSeparatedRoles = reviewTask?.args['reviewer_roles'];
-      const roles: string[] = commaSeparatedRoles.split(',');
+      const roles: string[] = commaSeparatedRoles?.split(',') ?? [];
 
       if (!roles) {
         continue;

--- a/src/modules/workflows/workflows.service.ts
+++ b/src/modules/workflows/workflows.service.ts
@@ -136,7 +136,7 @@ export class WorkflowsService {
 
     const roleNameList = rolesList?.map((r) => r.name.toLowerCase());
 
-    if (roles?.every((r) => roleNameList?.includes(r.toLowerCase()))) {
+    if (roles?.every((r) => roleNameList?.includes(r.trim().toLowerCase()))) {
       return true;
     }
 

--- a/src/modules/workflows/workflows.service.ts
+++ b/src/modules/workflows/workflows.service.ts
@@ -110,7 +110,8 @@ export class WorkflowsService {
     let failed = false;
 
     for (const reviewTask of clinicalReviewTasks) {
-      const roles = reviewTask?.args['reviewer_roles'];
+      const commaSeparatedRoles = reviewTask?.args['reviewer_roles'];
+      const roles: string[] = commaSeparatedRoles.split(',');
 
       if (!roles) {
         continue;


### PR DESCRIPTION
### Description

Fixes : The incoming comma separated roles need to be split into an array before an "every" check can happen on it

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New unit tests added to cover the changes.
- [ ] New e2e tests added to cover the changes. (If it has been decided these will not be added with the PR, a seperate ticket **must** be created and linked in the ticket below before merge)
- [ ] All tests passed locally.