### PR TITLE
AC-998 Corrected endpoint to return an arraybuffer for the DICOM file

### DIFF
--- a/src/modules/clinical-review/clinical-review.controller.spec.ts
+++ b/src/modules/clinical-review/clinical-review.controller.spec.ts
@@ -20,13 +20,16 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ClinicalReviewController } from './clinical-review.controller';
 import { ClinicalReviewAcknowledge } from './clinical-review.interfaces';
 import { ClinicalReviewService } from './clinical-review.service';
+import type { Response } from 'express';
 
 describe('ClinicalReviewController', () => {
   let controller: ClinicalReviewController;
   let clinicalReviewService: DeepMocked<ClinicalReviewService>;
+  let response: DeepMocked<Response>;
 
   beforeEach(async () => {
     clinicalReviewService = createMock<ClinicalReviewService>();
+    response = createMock<Response>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ClinicalReviewController],
@@ -170,7 +173,8 @@ describe('ClinicalReviewController', () => {
     it('passes the key to service', async () => {
       const key = '123abc';
       const roles = ['clinician'];
-      await controller.getDicomFile(roles, key);
+
+      await controller.getDicomFile(response, roles, key);
 
       expect(clinicalReviewService.getDicomFile).toHaveBeenCalledWith(
         roles,

--- a/test/e2e/clinical-review.e2e-spec.ts
+++ b/test/e2e/clinical-review.e2e-spec.ts
@@ -559,7 +559,10 @@ describe('/Clinical-Review Integration Tests', () => {
           minioKeyParams = request.url.searchParams.get('key');
           minioRolesParams = request.url.searchParams.get('roles');
 
-          return response(context.status(200));
+          return response(
+            context.status(200),
+            context.body(new ArrayBuffer(10)),
+          );
         },
       ),
     );
@@ -580,7 +583,7 @@ describe('/Clinical-Review Integration Tests', () => {
       rest.get(
         `${testClinicalReviewServiceBasePath}/dicom`,
         async (request, response, context) => {
-          return response(context.json({}), context.status(404));
+          return response(context.status(404));
         },
       ),
     );
@@ -589,7 +592,6 @@ describe('/Clinical-Review Integration Tests', () => {
       .set('Authorization', AuthTokens.authtokenValidRolesUserid);
 
     expect(response.status).toBe(404);
-    expect(response.body).toEqual({});
   });
 
   it('(GET) /clinical-review/dicom?key=minio-object-key returns Bad Request when roles have not been provided', async () => {


### PR DESCRIPTION
### Description

Fixes issue loading the DICOM for Clinical Review as the API wasn't serving the files correctly.

![AC-998](https://user-images.githubusercontent.com/11213454/205955115-6be6219d-c60e-4e88-b83b-b3f76eb3f1ea.gif)


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New unit tests added to cover the changes.
- [ ] New e2e tests added to cover the changes. (If it has been decided these will not be added with the PR, a seperate ticket **must** be created and linked in the ticket below before merge)
- [x] All tests passed locally.